### PR TITLE
complete task

### DIFF
--- a/README.md
+++ b/README.md
@@ -957,5 +957,11 @@ This is a repository with my solutions to problems from www.leetcode.com.
         <td><a href="https://github.com/ololx/leetcode-solutions/tree/main/src/main/java/io/github/ololx/leetcode/solutions/medium/task2486/Solution.java">Solution</a></td>
         <td>MEDIUM</td>
     </tr>
+    <tr>
+        <td>157</td>
+        <td><a href="https://leetcode.com/problems/number-of-even-and-odd-bits">Number of Even and Odd Bits</a></td>
+        <td><a href="https://github.com/ololx/leetcode-solutions/tree/main/src/main/java/io/github/ololx/leetcode/solutions/easy/task2595/Solution.java">Solution</a></td>
+        <td>EASY</td>
+    </tr>
 
 </table>

--- a/src/main/java/io/github/ololx/leetcode/solutions/easy/task2595/Solution.java
+++ b/src/main/java/io/github/ololx/leetcode/solutions/easy/task2595/Solution.java
@@ -1,0 +1,55 @@
+package io.github.ololx.leetcode.solutions.easy.task2595;
+
+/**
+ * 2595. Number of Even and Odd Bits
+ *
+ * You are given a positive integer n.
+ *
+ * Let even denote the number of even indices in the binary representation of
+ * n (0-indexed) with value 1.
+ *
+ * Let odd denote the number of odd indices in the binary representation of n
+ * (0-indexed) with value 1.
+ *
+ * Return an integer array answer where answer = [even, odd].
+ *
+ * Example 1:
+ * <p>Input: n = 17
+ * Output: [2,0]
+ * Explanation: The binary representation of 17 is 10001.
+ * It contains 1 on the 0th and 4th indices.
+ * There are 2 even and 0 odd indices.</p>
+ *
+ * Example 2:
+ * <p>Input: n = 2
+ * Output: [0,1]
+ * Explanation: The binary representation of 2 is 10.
+ * It contains 1 on the 1st index.
+ * There are 0 even and 1 odd indices.</p>
+ *
+ * Constraints:
+ * <ul>
+ *      <li>
+ *          1 <= n <= 1000
+ *      </li>
+ * </ul>
+ *
+ * project leetcode-solutions
+ * created 24.03.2023 09:49
+ *
+ * @author Alexander A. Kropotin
+ */
+public class Solution {
+
+    public int[] evenOddBit(int n) {
+        int evenCount = 0;
+        int oddCount = 0;
+
+        for (int evenBitPosition = 0, oddBitPosition = 1; oddBitPosition < 32; evenBitPosition += 2, oddBitPosition += 2) {
+            evenCount += 0x1 & (n >> evenBitPosition);
+            oddCount += 0x1 & (n >> oddBitPosition);
+        }
+
+        return new int[] {evenCount, oddCount};
+    }
+}

--- a/src/test/java/io/github/ololx/leetcode/solutions/easy/task2595/SolutionTest.java
+++ b/src/test/java/io/github/ololx/leetcode/solutions/easy/task2595/SolutionTest.java
@@ -1,0 +1,31 @@
+package io.github.ololx.leetcode.solutions.easy.task2595;
+
+import io.github.ololx.cranberry.logging.annotation.LogParam;
+import io.github.ololx.leetcode.solutions.easy.task2595.Solution;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * project leetcode-solutions
+ * created 24.03.2023 09:49
+ *
+ * @author Alexander A. Kropotin
+ */
+public class SolutionTest {
+
+    @DataProvider
+    public static Object[][] providesN() {
+        return new Object[][] {
+                {17, new int[] {2, 0}},
+                {2, new int[] {0, 1}}
+        };
+    }
+
+    @LogParam
+    @Test(dataProvider = "providesN")
+    public void evenOddBit_whenNumberIsNotNull_thenReturnEvenAndOddBitCount(int n, int[] expected) {
+        assertEquals(new Solution().evenOddBit(n), expected);
+    }
+}


### PR DESCRIPTION
2595. Number of Even and Odd Bits

You are given a positive integer n.

Let even denote the number of even indices in the binary representation of n (0-indexed) with value 1.

Let odd denote the number of odd indices in the binary representation of n (0-indexed) with value 1.

Return an integer array answer where answer = [even, odd].

 

Example 1:

Input: n = 17
Output: [2,0]
Explanation: The binary representation of 17 is 10001. 
It contains 1 on the 0th and 4th indices. 
There are 2 even and 0 odd indices.
Example 2:

Input: n = 2
Output: [0,1]
Explanation: The binary representation of 2 is 10.
It contains 1 on the 1st index. 
There are 0 even and 1 odd indices.
 

Constraints:

1 <= n <= 1000